### PR TITLE
Close the previous connection on reconnecting.

### DIFF
--- a/lib/atom-twitter-timeline-view.coffee
+++ b/lib/atom-twitter-timeline-view.coffee
@@ -17,6 +17,8 @@ class AtomTwitterTimelineView extends ScrollView
 
   initialize: (@stream, @rest, @id, @query, @bufferSize, @eventBus, @mutedUserIds) ->
     super
+
+  attached: () ->
     @stream.on 'error', (err) -> throw err
     @stream.on "response", @removeLoadingImage
     @stream.on @id, @addItem
@@ -26,7 +28,7 @@ class AtomTwitterTimelineView extends ScrollView
 
   removeLoadingImage: => @loading.hide()
 
-  ditached: ->
+  detached: ->
     @stream.off @id, @addItem
     clearInterval @timer
     @timer = null

--- a/lib/twitter-stream.coffee
+++ b/lib/twitter-stream.coffee
@@ -1,6 +1,5 @@
 uuid = require 'uuid'
 {Emitter} = require 'atom'
-# TwitterStreamClient = require "./twitter-stream-client"
 {userStream, publicStream} = require "twitter-streaming-client"
 
 class TwitterStream extends Emitter
@@ -45,11 +44,11 @@ class PublicStream extends TwitterStream
     id
 
 class UserStream extends TwitterStream
-  initialize: ->
-    @client = userStream @oauth
-
   connect: ->
     id = "tweet-user"
+
+    @client.close() if @client?
+    @client = userStream @oauth
 
     @client.on "status", (status) => @emit id, status
     @client.on "error", @onError


### PR DESCRIPTION
Close the previous connection on reconnecting when closing the user stream.
This modification prevents from emitting same statuses several times when reopening user stream.

closes #15.
